### PR TITLE
Fix protobuf package name

### DIFF
--- a/protobuf/pb.go
+++ b/protobuf/pb.go
@@ -1,4 +1,4 @@
-package mc_cbor
+package mc_pb
 
 import (
 	"errors"

--- a/protobuf/pb_test.go
+++ b/protobuf/pb_test.go
@@ -1,4 +1,4 @@
-package mc_cbor
+package mc_pb
 
 import (
 	"reflect"


### PR DESCRIPTION
Package name for protobuf multicodec referred to cbor instead.  Fixed here.