### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# go-multicodec - [multicodec](https://github.com/jbenet/multicodec) in Go
+# go-multicodec - [multicodec](https://github.com/multiformats/multicodec) in Go
 
 self-describing serialization. This is a Golang implementation of https://github.com/jbenet/multicodec
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/jbenet/multicodec | https://github.com/multiformats/multicodec 
