### PR TITLE
Add msgpack codec (based on https://godoc.org/github.com/ugorji/go)

### DIFF
--- a/msgpack/msgpack.go
+++ b/msgpack/msgpack.go
@@ -2,7 +2,6 @@ package mc_msgpack
 
 import (
 	"io"
-	"reflect"
 
 	mc "github.com/multiformats/go-multicodec"
 	gocodec "github.com/ugorji/go/codec"
@@ -11,92 +10,43 @@ import (
 var HeaderPath string
 var Header []byte
 
-// Handler options. See go/codec docs for their meanings.
-var (
-	// MsgpackHandle
-	RawToString bool
-	WriteExt    bool
-
-	// BasicHandle
-	TypeInfos *gocodec.TypeInfos
-
-	// Encode options
-	StructToArray       bool
-	Canonical           bool
-	CheckCircularRef    bool
-	RecursiveEmptyCheck bool
-	Raw                 bool
-	AsSymbols           gocodec.AsSymbolFlag
-
-	// Decode options
-	MapType              reflect.Type
-	SliceType            reflect.Type
-	MaxInitLen           int
-	ErrorIfNoField       bool
-	ErrorIfNoArrayExpand bool
-	SignedInteger        bool
-	MapValueReset        bool
-	InterfaceReset       bool
-	InternString         bool
-	PreferArrayOverSlice bool
-)
-
 func init() {
 	HeaderPath = "/msgpack"
 	Header = mc.Header([]byte(HeaderPath))
 }
 
 type codec struct {
-	mc bool
+	mc     bool
+	handle *gocodec.MsgpackHandle
 }
 
-func Codec() mc.Codec {
+func Codec(h *gocodec.MsgpackHandle) mc.Codec {
 	return &codec{
-		mc: false,
+		mc:     false,
+		handle: h,
 	}
 }
 
-func Multicodec() mc.Multicodec {
+func Multicodec(h *gocodec.MsgpackHandle) mc.Multicodec {
 	return &codec{
-		mc: true,
+		mc:     true,
+		handle: h,
 	}
 }
 
 func (c *codec) Encoder(w io.Writer) mc.Encoder {
-	h := &gocodec.MsgpackHandle{}
-	h.RawToString = RawToString
-	h.WriteExt = WriteExt
-	h.TypeInfos = TypeInfos
-	h.StructToArray = StructToArray
-	h.Canonical = Canonical
-	h.CheckCircularRef = CheckCircularRef
-	h.Raw = Raw
-	h.AsSymbols = AsSymbols
 	return &encoder{
 		w:   w,
 		mc:  c.mc,
-		enc: gocodec.NewEncoder(w, h),
+		enc: gocodec.NewEncoder(w, c.handle),
 	}
 }
 
 func (c *codec) Decoder(r io.Reader) mc.Decoder {
-	h := &gocodec.MsgpackHandle{}
-	h.RawToString = RawToString
-	h.WriteExt = WriteExt
-	h.TypeInfos = TypeInfos
-	h.MapType = MapType
-	h.SliceType = SliceType
-	h.MaxInitLen = MaxInitLen
-	h.ErrorIfNoField = ErrorIfNoField
-	h.SignedInteger = SignedInteger
-	h.MapValueReset = MapValueReset
-	h.InterfaceReset = InterfaceReset
-	h.InternString = InternString
-	h.PreferArrayOverSlice = PreferArrayOverSlice
 	return &decoder{
 		r:   r,
 		mc:  c.mc,
-		dec: gocodec.NewDecoder(r, h),
+		dec: gocodec.NewDecoder(r, c.handle),
 	}
 }
 

--- a/msgpack/msgpack.go
+++ b/msgpack/msgpack.go
@@ -2,6 +2,7 @@ package mc_msgpack
 
 import (
 	"io"
+	"reflect"
 
 	mc "github.com/multiformats/go-multicodec"
 	gocodec "github.com/ugorji/go/codec"
@@ -9,6 +10,36 @@ import (
 
 var HeaderPath string
 var Header []byte
+
+// Handler options. See go/codec docs for their meanings.
+var (
+	// MsgpackHandle
+	RawToString bool
+	WriteExt    bool
+
+	// BasicHandle
+	TypeInfos *gocodec.TypeInfos
+
+	// Encode options
+	StructToArray       bool
+	Canonical           bool
+	CheckCircularRef    bool
+	RecursiveEmptyCheck bool
+	Raw                 bool
+	AsSymbols           gocodec.AsSymbolFlag
+
+	// Decode options
+	MapType              reflect.Type
+	SliceType            reflect.Type
+	MaxInitLen           int
+	ErrorIfNoField       bool
+	ErrorIfNoArrayExpand bool
+	SignedInteger        bool
+	MapValueReset        bool
+	InterfaceReset       bool
+	InternString         bool
+	PreferArrayOverSlice bool
+)
 
 func init() {
 	HeaderPath = "/msgpack"
@@ -33,7 +64,14 @@ func Multicodec() mc.Multicodec {
 
 func (c *codec) Encoder(w io.Writer) mc.Encoder {
 	h := &gocodec.MsgpackHandle{}
-	h.Canonical = true
+	h.RawToString = RawToString
+	h.WriteExt = WriteExt
+	h.TypeInfos = TypeInfos
+	h.StructToArray = StructToArray
+	h.Canonical = Canonical
+	h.CheckCircularRef = CheckCircularRef
+	h.Raw = Raw
+	h.AsSymbols = AsSymbols
 	return &encoder{
 		w:   w,
 		mc:  c.mc,
@@ -43,7 +81,18 @@ func (c *codec) Encoder(w io.Writer) mc.Encoder {
 
 func (c *codec) Decoder(r io.Reader) mc.Decoder {
 	h := &gocodec.MsgpackHandle{}
-	h.Canonical = true
+	h.RawToString = RawToString
+	h.WriteExt = WriteExt
+	h.TypeInfos = TypeInfos
+	h.MapType = MapType
+	h.SliceType = SliceType
+	h.MaxInitLen = MaxInitLen
+	h.ErrorIfNoField = ErrorIfNoField
+	h.SignedInteger = SignedInteger
+	h.MapValueReset = MapValueReset
+	h.InterfaceReset = InterfaceReset
+	h.InternString = InternString
+	h.PreferArrayOverSlice = PreferArrayOverSlice
 	return &decoder{
 		r:   r,
 		mc:  c.mc,

--- a/msgpack/msgpack.go
+++ b/msgpack/msgpack.go
@@ -1,0 +1,88 @@
+package mc_msgpack
+
+import (
+	"io"
+
+	mc "github.com/multiformats/go-multicodec"
+	gocodec "github.com/ugorji/go/codec"
+)
+
+var HeaderPath string
+var Header []byte
+
+func init() {
+	HeaderPath = "/msgpack"
+	Header = mc.Header([]byte(HeaderPath))
+}
+
+type codec struct {
+	mc bool
+}
+
+func Codec() mc.Codec {
+	return &codec{
+		mc: false,
+	}
+}
+
+func Multicodec() mc.Multicodec {
+	return &codec{
+		mc: true,
+	}
+}
+
+func (c *codec) Encoder(w io.Writer) mc.Encoder {
+	h := &gocodec.MsgpackHandle{}
+	h.Canonical = true
+	return &encoder{
+		w:   w,
+		mc:  c.mc,
+		enc: gocodec.NewEncoder(w, h),
+	}
+}
+
+func (c *codec) Decoder(r io.Reader) mc.Decoder {
+	h := &gocodec.MsgpackHandle{}
+	h.Canonical = true
+	return &decoder{
+		r:   r,
+		mc:  c.mc,
+		dec: gocodec.NewDecoder(r, h),
+	}
+}
+
+func (c *codec) Header() []byte {
+	return Header
+}
+
+type encoder struct {
+	w   io.Writer
+	mc  bool
+	enc *gocodec.Encoder
+}
+
+type decoder struct {
+	r   io.Reader
+	mc  bool
+	dec *gocodec.Decoder
+}
+
+func (c *encoder) Encode(v interface{}) error {
+	// if multicodec, write the header first
+	if c.mc {
+		if _, err := c.w.Write(Header); err != nil {
+			return err
+		}
+	}
+	return c.enc.Encode(v)
+}
+
+func (c *decoder) Decode(v interface{}) error {
+	// if multicodec, consume the header first
+	if c.mc {
+		if err := mc.ConsumeHeader(c.r, Header); err != nil {
+			return err
+		}
+	}
+	return c.dec.Decode(v)
+}

--- a/msgpack/msgpack.go
+++ b/msgpack/msgpack.go
@@ -7,13 +7,9 @@ import (
 	gocodec "github.com/ugorji/go/codec"
 )
 
-var HeaderPath string
-var Header []byte
+const HeaderPath = "/msgpack"
 
-func init() {
-	HeaderPath = "/msgpack"
-	Header = mc.Header([]byte(HeaderPath))
-}
+var Header = mc.Header([]byte(HeaderPath))
 
 type codec struct {
 	mc     bool

--- a/msgpack/msgpack.go
+++ b/msgpack/msgpack.go
@@ -27,6 +27,10 @@ func Codec(h *gocodec.MsgpackHandle) mc.Codec {
 	}
 }
 
+func DefaultMsgpackHandle() *gocodec.MsgpackHandle {
+	return &gocodec.MsgpackHandle{}
+}
+
 func Multicodec(h *gocodec.MsgpackHandle) mc.Multicodec {
 	return &codec{
 		mc:     true,

--- a/msgpack/msgpack_test.go
+++ b/msgpack/msgpack_test.go
@@ -1,0 +1,81 @@
+package mc_msgpack
+
+import (
+	"testing"
+	"testing/quick"
+
+	mctest "github.com/multiformats/go-multicodec/test"
+)
+
+var testCases []interface{}
+
+func init() {
+	tc1 := map[string]string{
+		"hello": "world",
+	}
+
+	tc2 := map[string]int{
+		"a": 1,
+		"b": 2,
+		"c": 3,
+	}
+
+	tc3 := map[string]interface{}{
+		"a": 1,
+		"b": "hello",
+		"c": map[string]interface{}{
+			"c/a": 1,
+			"c/b": "world",
+			"c/c": []int{1, 2, 3, 4},
+		},
+	}
+
+	testCases = []interface{}{tc1, tc2, tc3}
+}
+
+type TestType map[string]map[string]string
+
+func TestRoundtripBasic(t *testing.T) {
+	codec := Codec()
+	for _, tca := range testCases {
+		var tcb map[string]interface{}
+		mctest.RoundTripTest(t, codec, &tca, &tcb)
+	}
+}
+
+func TestRoundtripCheck(t *testing.T) {
+	codec := Codec()
+	f := func(o1 TestType) bool {
+		var o2 TestType
+		return mctest.RoundTripTest(t, codec, &o1, &o2)
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestHeaderMC(t *testing.T) {
+	codec := Multicodec()
+	for _, tc := range testCases {
+		mctest.HeaderTest(t, codec, &tc)
+	}
+}
+
+func TestRoundtripBasicMC(t *testing.T) {
+	codec := Multicodec()
+	for _, tca := range testCases {
+		var tcb map[string]interface{}
+		mctest.RoundTripTest(t, codec, &tca, &tcb)
+	}
+}
+
+func TestRoundtripCheckMC(t *testing.T) {
+	codec := Multicodec()
+	f := func(o1 TestType) bool {
+		var o2 TestType
+		return mctest.RoundTripTest(t, codec, &o1, &o2)
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}

--- a/msgpack/msgpack_test.go
+++ b/msgpack/msgpack_test.go
@@ -5,11 +5,10 @@ import (
 	"testing/quick"
 
 	mctest "github.com/multiformats/go-multicodec/test"
-	gocodec "github.com/ugorji/go/codec"
 )
 
 var testCases []interface{}
-var handle = &gocodec.MsgpackHandle{}
+var handle = DefaultMsgpackHandle()
 
 func init() {
 	// Make sure we always generate the same encoded data for the

--- a/msgpack/msgpack_test.go
+++ b/msgpack/msgpack_test.go
@@ -10,6 +10,10 @@ import (
 var testCases []interface{}
 
 func init() {
+	// Make sure we always generate the same encoded data for the
+	// same input
+	Canonical = true
+
 	tc1 := map[string]string{
 		"hello": "world",
 	}

--- a/msgpack/msgpack_test.go
+++ b/msgpack/msgpack_test.go
@@ -5,14 +5,16 @@ import (
 	"testing/quick"
 
 	mctest "github.com/multiformats/go-multicodec/test"
+	gocodec "github.com/ugorji/go/codec"
 )
 
 var testCases []interface{}
+var handle = &gocodec.MsgpackHandle{}
 
 func init() {
 	// Make sure we always generate the same encoded data for the
 	// same input
-	Canonical = true
+	handle.Canonical = true
 
 	tc1 := map[string]string{
 		"hello": "world",
@@ -40,7 +42,7 @@ func init() {
 type TestType map[string]map[string]string
 
 func TestRoundtripBasic(t *testing.T) {
-	codec := Codec()
+	codec := Codec(handle)
 	for _, tca := range testCases {
 		var tcb map[string]interface{}
 		mctest.RoundTripTest(t, codec, &tca, &tcb)
@@ -48,7 +50,7 @@ func TestRoundtripBasic(t *testing.T) {
 }
 
 func TestRoundtripCheck(t *testing.T) {
-	codec := Codec()
+	codec := Codec(handle)
 	f := func(o1 TestType) bool {
 		var o2 TestType
 		return mctest.RoundTripTest(t, codec, &o1, &o2)
@@ -59,14 +61,14 @@ func TestRoundtripCheck(t *testing.T) {
 }
 
 func TestHeaderMC(t *testing.T) {
-	codec := Multicodec()
+	codec := Multicodec(handle)
 	for _, tc := range testCases {
 		mctest.HeaderTest(t, codec, &tc)
 	}
 }
 
 func TestRoundtripBasicMC(t *testing.T) {
-	codec := Multicodec()
+	codec := Multicodec(handle)
 	for _, tca := range testCases {
 		var tcb map[string]interface{}
 		mctest.RoundTripTest(t, codec, &tca, &tcb)
@@ -74,7 +76,7 @@ func TestRoundtripBasicMC(t *testing.T) {
 }
 
 func TestRoundtripCheckMC(t *testing.T) {
-	codec := Multicodec()
+	codec := Multicodec(handle)
 	f := func(o1 TestType) bool {
 		var o2 TestType
 		return mctest.RoundTripTest(t, codec, &o1, &o2)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
       "hash": "QmPL3RCWaM6s7b82LSLS1MGX2jpxPxA1v2vmgLm15b1NcW",
       "name": "cbor",
       "version": "0.2.0"
+    },
+    {
+      "author": "ugorji",
+      "hash": "QmRpRGNbrm6aaU7bnt6AwcJCfyETkdJzmtBdCazMYKoMux",
+      "name": "go-codec",
+      "version": "2017.1.3"
     }
   ],
   "gxVersion": "0.9.1",


### PR DESCRIPTION
My impression so far is that ugorji/go codecs are very mature. This wraps msgpack as multicodec. All very inspired in current mc_cbor.