### PR TITLE
gx: update cbor

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.1.2: QmVRuqGJ881CFiNLgwWSfRVjTjqQ6FeCNufkftNC4fpACZ
+0.1.3: QmU4qokxecGJBZPGmc4D9g2HdTyo8CPqUoZ2gwXKsQxqc9

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmVQfuckfPnW5LGmgSWsJVJr6Xea1bWXD8sBixe8E9MQD6",
+      "hash": "QmcRKRQjNc2JZPHApR32fbkZVd6WXG2Ch9Kcy7sPxuAJgd",
       "name": "cbor",
-      "version": "0.2.1"
+      "version": "0.2.3"
     },
     {
       "author": "ugorji",
@@ -37,6 +37,6 @@
   "license": "MIT",
   "name": "go-multicodec",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.1.2"
+  "version": "0.1.3"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/ipfs/go-ipld-cbor/pull/28


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace