### PR TITLE
dep ugorji/go-codec: update to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     },
     {
       "author": "ugorji",
-      "hash": "QmRpRGNbrm6aaU7bnt6AwcJCfyETkdJzmtBdCazMYKoMux",
+      "hash": "QmVTAmbCaPqdfbmpWDCJMQNFxbyJoG2USFsumXmTWY5LFp",
       "name": "go-codec",
-      "version": "2017.1.3"
+      "version": "2017.10.18"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
From gxed/go-codec.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>