### PR TITLE
Add minimal Makefile and update Travis CI to use standard test script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,14 @@ os:
 language: go
 
 go:
-  - 1.7
+  - 1.9.x
+
+install:
+  - make deps
 
 script:
-  - go test -race -cpu 5 ./...
+  - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
 
 sudo: false #docker containers for CI
+
+env: GOTFLAGS="-race -cpu 5"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+gx:
+	go get github.com/whyrusleeping/gx
+	go get github.com/whyrusleeping/gx-go
+
+deps: gx
+	gx --verbose install --global
+	gx-go rewrite
+
+publish:
+	gx-go rewrite --undo
+

--- a/header_test.go
+++ b/header_test.go
@@ -35,7 +35,7 @@ func TestTestWrapP2H(t *testing.T) {
 
 	outS := string(out)
 	if outS != "data" {
-		t.Fatal("data is not equal, got %s", outS)
+		t.Fatalf("data is not equal, got %s", outS)
 	}
 
 }

--- a/multicodec/main.go
+++ b/multicodec/main.go
@@ -274,8 +274,6 @@ func decode(r io.Reader, next func(m *mux.Multicodec, v interface{}) error) erro
 			return err
 		}
 	}
-
-	return nil
 }
 
 func codecWithPath(path string) mc.Multicodec {


### PR DESCRIPTION
This also bumps the go version to 1.9.x.
