### PR TITLE
README: deprecate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: go
 
 go:
-  - 1.9.x
+  - 1.11.x
 
 install:
   - make deps

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
+# Deprecated
+
+**NOTE:** *Multicodec* is not deprecated, just this library.
+
+This library has been deprecated to reduce confusion concerning the multicodec project. It is *not* an implementation of multicodec as it exists today (as described in the [project's README](https://github.com/multiformats/multicodec)). Instead, it's closer to the *multistream* protocol but we already have an actively used `go-multistream` repository (for multistream-select).
+
+*This library will not be maintained.*
+
+---
+
 # go-multicodec
+
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](https://github.com/multiformats/multiformats)


### PR DESCRIPTION
At this point, multicodec refers to the multicodec table. Multicodec "formats" refer to formats in the form `<multicodec (varint)><data>`. Everything in *this* repo is closer to multi*stream*.

Note: None of the other *lang*-multicodec repos look *anything* like this one. They all include the multicodec table (and nothing else).

Next steps:

* [ ] Stop using this in go-libp2p-pnet (we can reimplement what we need there, we don't need much).
* [ ] Stop using this in libp2p examples.
* [ ] Create a `go-multicodec-table` repo, linking to it from here. Unfortunately, we can't just remove/rename this repo without affecting users.
* [ ] Unify these concepts with multistream.