### PR TITLE
docs(readme): improved usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,18 @@
 
 	go get github.com/multiformats/go-multicodec
 
+
+## Type
+
+`Code` describes an integer reserved in the multicodec table, defined at [multiformats/multicodec/table.csv](https://github.com/multiformats/multicodec/blob/master/table.csv).
+
+```go
+type Code uint64
+```
+
 ## Usage
+
+### Importing Code constant
 
 ```go
 package main
@@ -27,11 +38,26 @@ package main
 import "github.com/multiformats/go-multicodec"
 
 func main() {
-	_ = multicodec.Sha2_256
+	code := multicodec.Sha2_256 // Code
+	name := multicodec.Sha2_256.String()
 }
 ```
 
 The corresponding `name` value for each codec from the [multicodecs table](https://raw.githubusercontent.com/multiformats/multicodec/master/table.csv) can be accessed via its `String` method. For example, `multicodec.Sha2_256.String()` will return `sha2-256`.
+
+### Code from string
+
+```go
+var multicodec.Code code 
+err := code.Set("libp2p-key")
+```
+
+
+### Code from uint64
+
+```go
+rawCode := multicodec.Code(0x55)
+```
 
 ## Generator
 


### PR DESCRIPTION
Small README update that should make it easier for people to migrate from go-cid mappings to this library (details in https://github.com/ipfs/go-cid/pull/137)