### PR TITLE
Bump version to release `ipns-record` code

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.8.0"
+  "version": "v0.8.1"
 }


### PR DESCRIPTION
Bump version in preparation to release a tag that includes the latest `ipns-record` code.